### PR TITLE
Refactor data modules for immutability and add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+- Follow the guidelines in `docs/engineering-guide.md`.
+- Use TypeScript with `strict` typing; never introduce `any`.
+- Make data structures immutable where practical with `readonly`.
+- Exported functions and methods require explicit return types.
+- Keep side effects in dedicated platform modules.
+- Before committing, run:
+    - `npm run lint`
+    - `npm run type-check`
+    - `npm test`

--- a/src/data/csvProcessor.ts
+++ b/src/data/csvProcessor.ts
@@ -12,7 +12,7 @@ export class CSVTimeSeriesData implements TimeSeriesData {
     public readonly id: string;
     public readonly name: string;
     public readonly columns: readonly string[];
-    private parsedData: number[][] = [];
+    private parsedData: ReadonlyArray<readonly number[]> = [];
     private labeled = false;
 
     constructor(file: TDataFile) {
@@ -25,7 +25,7 @@ export class CSVTimeSeriesData implements TimeSeriesData {
         this.parsedData = data;
     }
 
-    getData(xColumn: string, yColumn: string): Array<[number, number]> {
+    getData(xColumn: string, yColumn: string): ReadonlyArray<readonly [number, number]> {
         const xIndex = this.columns.indexOf(xColumn);
         const yIndex = this.columns.indexOf(yColumn);
 
@@ -36,7 +36,7 @@ export class CSVTimeSeriesData implements TimeSeriesData {
         return this.parsedData.map((row, index) => {
             const xValue = xIndex < row.length ? (row[xIndex] ?? index) : index;
             const yValue = yIndex < row.length ? (row[yIndex] ?? 0) : 0;
-            return [xValue, yValue];
+            return [xValue, yValue] as const;
         });
     }
 
@@ -77,7 +77,12 @@ function parseNumericValue(value: string): number {
 /**
  * Parse CSV text into columns and numeric data
  */
-function parseCSV(text: string): { columns: string[]; data: number[][] } {
+type ParsedCSV = {
+    readonly columns: readonly string[];
+    readonly data: ReadonlyArray<readonly number[]>;
+};
+
+function parseCSV(text: string): ParsedCSV {
     const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
 
     if (lines.length === 0) {
@@ -206,7 +211,7 @@ function tryParseTime(value: string): number {
 /**
  * Convert uploaded data files to TimeSeriesData array
  */
-export function convertDataFilesToTimeSeries(files: TDataFile[]): TimeSeriesData[] {
+export function convertDataFilesToTimeSeries(files: TDataFile[]): ReadonlyArray<TimeSeriesData> {
     return files
         .filter((file) => file.visible && file.text && file.text.trim().length > 0)
         .map((file) => new CSVTimeSeriesData(file));

--- a/src/data/dataManager.ts
+++ b/src/data/dataManager.ts
@@ -11,8 +11,8 @@ import { convertDataFilesToTimeSeries } from './csvProcessor';
  * Implementation of DataManager that listens to uploaded data files
  */
 export class UploadDataManager implements DataManager {
-    private dataSources: TimeSeriesData[] = [];
-    private callbacks = new Set<(sources: TimeSeriesData[]) => void>();
+    private dataSources: ReadonlyArray<TimeSeriesData> = [];
+    private callbacks = new Set<(sources: readonly TimeSeriesData[]) => void>();
 
     constructor() {
         // Listen for data file changes
@@ -22,15 +22,15 @@ export class UploadDataManager implements DataManager {
         this.loadInitialData();
     }
 
-    getDataSources(): Promise<TimeSeriesData[]> {
+    getDataSources(): Promise<readonly TimeSeriesData[]> {
         return Promise.resolve([...this.dataSources]);
     }
 
-    onDataChanged(callback: (sources: TimeSeriesData[]) => void): void {
+    onDataChanged(callback: (sources: readonly TimeSeriesData[]) => void): void {
         this.callbacks.add(callback);
     }
 
-    offDataChanged(callback: (sources: TimeSeriesData[]) => void): void {
+    offDataChanged(callback: (sources: readonly TimeSeriesData[]) => void): void {
         this.callbacks.delete(callback);
     }
 
@@ -55,7 +55,7 @@ export class UploadDataManager implements DataManager {
     }
 
     private notifyDataChanged(): void {
-        const sourcesCopy = [...this.dataSources];
+        const sourcesCopy: readonly TimeSeriesData[] = [...this.dataSources];
         this.callbacks.forEach((callback) => {
             try {
                 callback(sourcesCopy);


### PR DESCRIPTION
## Summary
- enforce readonly data flow in CSV processing and data manager
- update time-series chart interfaces for immutable arrays
- add root AGENTS file referencing the engineering guide
- auto-scale time series charts based on zoomed data

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b303b62444832b8be0b8851eeef838