### PR TITLE
chore: configure static build and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ A simple time series data labeling tool.
 | `npm run format`        | Format code with Prettier.              |
 | `npm run type-check`    | Check TypeScript types.                 |
 | `npm run ci`            | Run all checks (CI pipeline).           |
+
+## Building & deployment
+
+To create a production build with static assets:
+
+```bash
+npm run build
+```
+
+This outputs the app to the `dist/` directory with **relative asset paths** so it can be served from any URL prefix.
+Verify the output locally with:
+
+```bash
+npm run preview
+```
+
+### Hosting
+
+- **Any static server**: copy the contents of `dist/` to your server's public directory.
+- **Vercel**: the included `vercel.json` config uses `npm run build` and serves the `dist/` folder.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "builds": [{ "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }],
+  "routes": [{ "src": "/(.*)", "dest": "/index.html" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+    base: './',
     resolve: {
         alias: {
             '@': resolve(__dirname, 'src'),
@@ -43,5 +44,6 @@ export default defineConfig({
     },
     preview: {
         port: 4173,
+        open: false,
     },
 });


### PR DESCRIPTION
## Summary
- serve built assets with relative paths by setting Vite `base` to `./`
- prevent preview from trying to open a browser and add Vercel static build config
- document building and hosting steps for static deployments

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`
- `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/assets/index-BV2DnAGA.js`


------
https://chatgpt.com/codex/tasks/task_e_68b30927b880832bb8d5669df5a18e01