### PR TITLE
Add interactive time series labeling

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,15 @@
                     >
                         <span class="material-symbols-outlined">point_scan</span>
                     </button>
+                    <button
+                        class="btn-icon btn-neutral"
+                        id="btn-label-mode"
+                        aria-pressed="false"
+                        aria-label="Label mode"
+                        title="Toggle labeling mode"
+                    >
+                        <span class="material-symbols-outlined">ink_highlighter</span>
+                    </button>
                     <!-- Collapse/expand side panels -->
                     <button
                         class="btn-icon btn-neutral"

--- a/src/charts/timeSeries.ts
+++ b/src/charts/timeSeries.ts
@@ -102,6 +102,8 @@ export class TimeSeriesChart {
         overlay.style.position = 'absolute';
         overlay.style.inset = '0';
         overlay.style.pointerEvents = 'none';
+        overlay.style.zIndex = '10';
+        overlay.style.touchAction = 'none';
         container.appendChild(overlay);
         overlay.addEventListener('pointerdown', this.handleLabelStart);
         overlay.addEventListener('pointermove', this.handleLabelMove);
@@ -461,6 +463,9 @@ export class TimeSeriesChart {
         if (!this.labelMode || !this.labelOverlay) {
             return;
         }
+        e.stopPropagation();
+        e.preventDefault();
+        this.labelOverlay.setPointerCapture(e.pointerId);
         this.labelStartX = e.offsetX;
         const def = this.getActiveLabelDefinition();
         if (!def) {
@@ -480,6 +485,8 @@ export class TimeSeriesChart {
         if (!this.labelMode || this.labelStartX === null || !this.activeLabelRect) {
             return;
         }
+        e.stopPropagation();
+        e.preventDefault();
         const currentX = e.offsetX;
         const left = Math.min(this.labelStartX, currentX);
         const width = Math.abs(currentX - this.labelStartX);
@@ -491,6 +498,11 @@ export class TimeSeriesChart {
         if (!this.labelMode || this.labelStartX === null || !this.chart || !this.activeLabelRect) {
             this.cleanupActiveRect();
             return;
+        }
+        e.stopPropagation();
+        e.preventDefault();
+        if (this.labelOverlay) {
+            this.labelOverlay.releasePointerCapture(e.pointerId);
         }
         const endX = e.offsetX;
         const startPx = this.labelStartX;

--- a/src/charts/timeSeries.ts
+++ b/src/charts/timeSeries.ts
@@ -440,6 +440,9 @@ export class TimeSeriesChart {
         if (this.labelOverlay) {
             this.labelOverlay.style.pointerEvents = this.labelMode ? 'auto' : 'none';
         }
+        if (this.chart) {
+            this.chart.getDom().style.pointerEvents = this.labelMode ? 'none' : 'auto';
+        }
         if (!this.labelMode) {
             this.cleanupActiveRect();
         }

--- a/src/charts/timeSeries.ts
+++ b/src/charts/timeSeries.ts
@@ -105,7 +105,6 @@ export class TimeSeriesChart {
         overlay.style.pointerEvents = 'none';
         overlay.style.zIndex = '10';
         overlay.style.touchAction = 'none';
-        container.appendChild(overlay);
         overlay.addEventListener('pointerdown', this.handleLabelStart);
         overlay.addEventListener('pointermove', this.handleLabelMove);
         overlay.addEventListener('pointerup', this.handleLabelEnd);
@@ -145,6 +144,11 @@ export class TimeSeriesChart {
         void init(container as HTMLDivElement).then((chartInstance) => {
             this.chart = chartInstance;
             chartInstance.setOption(option);
+
+            // Reattach overlay after ECharts wipes the container
+            if (this.labelOverlay) {
+                container.appendChild(this.labelOverlay);
+            }
 
             // Create empty state element AFTER chart is ready
             this.createEmptyStateElement();

--- a/src/shared/misc.ts
+++ b/src/shared/misc.ts
@@ -16,3 +16,12 @@ export const formatBytes = (bytes: number): string => {
 
     return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
 };
+
+export function hexToRgba(hex: string, alpha: number): string {
+    const normalized = hex.replace('#', '');
+    const bigint = parseInt(normalized, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return 'rgba(' + String(r) + ', ' + String(g) + ', ' + String(b) + ', ' + String(alpha) + ')';
+}


### PR DESCRIPTION
## Summary
- allow toggling label mode and drawing colored regions on the chart
- store label definitions with data and persist to IndexedDB
- add utility for hex color conversion

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b595e7de18832bb89556ece6a383b3